### PR TITLE
Added automatic lockscreen dismissal config option

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -6,6 +6,11 @@ no_confirmation = false
 # show an error but fail silently
 suppress_unknown = false
 
+# Auto dismiss lock screen on confirmation
+# Will run loginctl unlock-sessions after every auth
+# Expirimental, can behave incorrectly on some systems
+dismiss_lockscreen = false
+
 [video]
 # The certainty of the detected face belonging to the user of the account
 # On a scale from 1 to 10, values above 5 are not recommended

--- a/pam.py
+++ b/pam.py
@@ -29,8 +29,15 @@ def doAuth(pamh):
 		return pamh.PAM_AUTH_ERR
 	# Status 0 is a successful exit
 	if status == 0:
+		# Show the success message if it isn't suppressed
 		if config.get("core", "no_confirmation") != "true":
 			pamh.conversation(pamh.Message(pamh.PAM_TEXT_INFO, "Identified face as " + pamh.get_user()))
+
+		# Try to dismiss the lock screen if enabled
+		if config.get("core", "dismiss_lockscreen") == "true":
+			# Run it as root with a timeout of 1s, and never ask for a password through the UI
+			subprocess.Popen(["sudo", "timeout", "1", "loginctl", "unlock-sessions", "--no-ask-password"])
+
 		return pamh.PAM_SUCCESS
 
 	# Otherwise, we can't discribe what happend but it wasn't successful


### PR DESCRIPTION
This fixes #13 and adds a new config option to dismiss the lockscreen immediately after we recognize the user.