### PR TITLE
Added notice that facial detection is occurring

### DIFF
--- a/src/config.ini
+++ b/src/config.ini
@@ -2,6 +2,9 @@
 # Press CTRL + X to save in the nano editor
 
 [core]
+# Print that face detection is being attempted
+show_detection_attempt = false
+
 # Do not print anything when a face verification succeeds
 no_confirmation = false
 

--- a/src/pam.py
+++ b/src/pam.py
@@ -24,6 +24,9 @@ def doAuth(pamh):
 		if "SSH_CONNECTION" in os.environ or "SSH_CLIENT" in os.environ or "SSHD_OPTS" in os.environ:
 			sys.exit(0)
 
+	# Alert the user that we are doing face detection	
+	pamh.conversation(pamh.Message(pamh.PAM_TEXT_INFO, "Attempting face detection"))
+
 	# Run compare as python3 subprocess to circumvent python version and import issues
 	status = subprocess.call(["/usr/bin/python3", os.path.dirname(os.path.abspath(__file__)) + "/compare.py", pamh.get_user()])
 

--- a/src/pam.py
+++ b/src/pam.py
@@ -24,8 +24,9 @@ def doAuth(pamh):
 		if "SSH_CONNECTION" in os.environ or "SSH_CLIENT" in os.environ or "SSHD_OPTS" in os.environ:
 			sys.exit(0)
 
-	# Alert the user that we are doing face detection	
-	pamh.conversation(pamh.Message(pamh.PAM_TEXT_INFO, "Attempting face detection"))
+	# Alert the user that we are doing face detection
+	if config.get("core", "show_detection_attempt") == "true":
+		pamh.conversation(pamh.Message(pamh.PAM_TEXT_INFO, "Attempting face detection"))
 
 	# Run compare as python3 subprocess to circumvent python version and import issues
 	status = subprocess.call(["/usr/bin/python3", os.path.dirname(os.path.abspath(__file__)) + "/compare.py", pamh.get_user()])


### PR DESCRIPTION
Added a pam conversation message that the facial detection is being performed.

**Why?**

In my setup, my webcam is not always "front and center". I often use external monitors on my laptop and my webcam ends up pointing toward the side of my face. In order to get face detection to work, I need to turn my head and look into the webcam.

I find myself forgetting to turn and look at the webcam when typing sudo from the command line. Then I either type my password or canceling it and trying again.

I added this message on my machine, and it works great to remind me to look at the webcam.