### PR TITLE
Added notification popup when it's running

### DIFF
--- a/src/config.ini
+++ b/src/config.ini
@@ -29,6 +29,9 @@ disabled = false
 # computational power to run, and is meant to be executed on a GPU to attain reasonable speed.
 use_cnn = false
 
+# Show a notification to the user when face detection is being attempted
+show_notification = true
+
 [video]
 # The certainty of the detected face belonging to the user of the account
 # On a scale from 1 to 10, values above 5 are not recommended

--- a/src/pam.py
+++ b/src/pam.py
@@ -25,6 +25,11 @@ def doAuth(pamh):
 		if "SSH_CONNECTION" in os.environ or "SSH_CLIENT" in os.environ or "SSHD_OPTS" in os.environ:
 			sys.exit(0)
 
+	# Send a notification to the user
+	if config.get("core", "show_notification") == "true":
+		cmd = "notify-send -i camera -t 4000 \"Howdy\" \"Authenticating with camera, please look directly into it...\""
+		os.system(cmd)	
+
 	# Alert the user that we are doing face detection
 	if config.get("core", "detection_notice") == "true":
 		pamh.conversation(pamh.Message(pamh.PAM_TEXT_INFO, "Attempting face detection"))


### PR DESCRIPTION
Added a notification/popup *(through `notify-send`)* to notify the user when the app is scanning faces.

The message, timeout and icon of the notification are examples, so they're obviously open for change.

I also made this feature optional by adding it to `config.ini`*(by default it's active: again, open for change)*