### PR TITLE
Add video_format options to opencv backend

### DIFF
--- a/src/cli/add.py
+++ b/src/cli/add.py
@@ -108,8 +108,16 @@ elif config.get("video", "recording_plugin") == "pyv4l2":
 	from recorders.pyv4l2_reader import pyv4l2_reader
 	video_capture = pyv4l2_reader(config.get("video", "device_path"), config.get("video", "device_format"))
 else:
+	# Lookup dictionary for different format strings in the config file -> opencv enum
+	opencv_api_pref = {
+		"v4l2"   : cv2.CAP_V4L2,
+		"vfwcap" : cv2.CAP_VFW
+	}
 	# Start video capture on the IR camera through OpenCV
-	video_capture = cv2.VideoCapture(config.get("video", "device_path"))
+	video_capture = cv2.VideoCapture(
+			config.get("video", "device_path"),
+			opencv_api_pref.get(config.get("video", "device_format"), cv2.CAP_V4L2)
+	)
 
 # Force MJPEG decoding if true
 if config.getboolean("video", "force_mjpeg", fallback=False):

--- a/src/cli/test.py
+++ b/src/cli/test.py
@@ -20,8 +20,16 @@ if config.get("video", "recording_plugin") != "opencv":
 	print("Aborting")
 	sys.exit(12)
 
-# Start capturing from the configured webcam
-video_capture = cv2.VideoCapture(config.get("video", "device_path"))
+# Lookup dictionary for different format strings in the config file -> opencv enum
+opencv_api_pref = {
+	"v4l2"   : cv2.CAP_V4L2,
+	"vfwcap" : cv2.CAP_VFW
+}
+# Start video capture on the IR camera through OpenCV
+video_capture = cv2.VideoCapture(
+		config.get("video", "device_path"),
+		opencv_api_pref.get(config.get("video", "device_format"), cv2.CAP_V4L2)
+)
 
 # Force MJPEG decoding if true
 if config.getboolean("video", "force_mjpeg", fallback=False):

--- a/src/compare.py
+++ b/src/compare.py
@@ -123,8 +123,16 @@ elif config.get("video", "recording_plugin") == "pyv4l2":
 	from recorders.pyv4l2_reader import pyv4l2_reader
 	video_capture = pyv4l2_reader(config.get("video", "device_path"), config.get("video", "device_format"))
 else:
+	# Lookup dictionary for different format strings in the config file -> opencv enum
+	opencv_api_pref = {
+		"v4l2"   : cv2.CAP_V4L2,
+		"vfwcap" : cv2.CAP_VFW
+	}
 	# Start video capture on the IR camera through OpenCV
-	video_capture = cv2.VideoCapture(config.get("video", "device_path"))
+	video_capture = cv2.VideoCapture(
+			config.get("video", "device_path"),
+			opencv_api_pref.get(config.get("video", "device_format"), cv2.CAP_V4L2)
+	)
 
 # Force MJPEG decoding if true
 if config.getboolean("video", "force_mjpeg", fallback=False):

--- a/src/config.ini
+++ b/src/config.ini
@@ -61,8 +61,8 @@ dark_threshold = 50
 # Switching from the default opencv to ffmpeg can help with grayscale issues.
 recording_plugin = opencv
 
-# Video format used by ffmpeg. Options include vfwcap or v4l2.
-# FFMPEG only.
+# Video format used by opencv/ffmpeg. Options include vfwcap or v4l2.
+# OPENCV and FFMPEG only.
 device_format = v4l2
 
 # Force the use of Motion JPEG when decoding frames, fixes issues with YUYV


### PR DESCRIPTION
Also fixes a bug with a GStreamer-CRITICAL error message appeared every time the `video_capture` was opened.

As an aside, there seems to be a lot of code duplication in setting up the `video_capture` objects, I may try clean that up into a utils file or something to that efffect, but I am not familiar enough to start refactoring the project! Let me know what you think :smiley:

----------------

Example of the bug mentioned above:
```
# G_DEBUG=fatal_warnings python compare.py username                                                                                       
```
Output:
```
(python:16551): GStreamer-CRITICAL **: 18:06:31.199: gst_element_get_state: assertion 'GST_IS_ELEMENT (element)' failed
[1]    16551 trace trap (core dumped)  G_DEBUG=fatal_warnings python -W error compare.py username
```
*(Note that the `G_DEBUG` environment variable in this example is there simply to crash the program when the error occurs. This message did not actually seem to stop execution in practise, but having a warning pop up all the time is a little bit irritating!)*