### PR TITLE
Add video_format options to opencv backend

### DIFF
--- a/src/cli/add.py
+++ b/src/cli/add.py
@@ -108,8 +108,16 @@ elif config.get("video", "recording_plugin") == "pyv4l2":
 	from recorders.pyv4l2_reader import pyv4l2_reader
 	video_capture = pyv4l2_reader(config.get("video", "device_path"), config.get("video", "device_format"))
 else:
+	# Lookup dictionary for different format strings in the config file -> opencv enum
+	opencv_api_pref = {
+		"v4l2"   : cv2.CAP_V4L2,
+		"vfwcap" : cv2.CAP_VFW
+	}
 	# Start video capture on the IR camera through OpenCV
-	video_capture = cv2.VideoCapture(config.get("video", "device_path"))
+	video_capture = cv2.VideoCapture(
+			config.get("video", "device_path"),
+			opencv_api_pref.get(config.get("video", "device_format"), cv2.CAP_V4L2)
+	)
 
 # Force MJPEG decoding if true
 if config.getboolean("video", "force_mjpeg", fallback=False):

--- a/src/cli/test.py
+++ b/src/cli/test.py
@@ -20,8 +20,16 @@ if config.get("video", "recording_plugin") != "opencv":
 	print("Aborting")
 	sys.exit(12)
 
-# Start capturing from the configured webcam
-video_capture = cv2.VideoCapture(config.get("video", "device_path"))
+# Lookup dictionary for different format strings in the config file -> opencv enum
+opencv_api_pref = {
+	"v4l2"   : cv2.CAP_V4L2,
+	"vfwcap" : cv2.CAP_VFW
+}
+# Start video capture on the IR camera through OpenCV
+video_capture = cv2.VideoCapture(
+		config.get("video", "device_path"),
+		opencv_api_pref.get(config.get("video", "device_format"), cv2.CAP_V4L2)
+)
 
 # Force MJPEG decoding if true
 if config.getboolean("video", "force_mjpeg", fallback=False):

--- a/src/compare.py
+++ b/src/compare.py
@@ -123,8 +123,16 @@ elif config.get("video", "recording_plugin") == "pyv4l2":
 	from recorders.pyv4l2_reader import pyv4l2_reader
 	video_capture = pyv4l2_reader(config.get("video", "device_path"), config.get("video", "device_format"))
 else:
+	# Lookup dictionary for different format strings in the config file -> opencv enum
+	opencv_api_pref = {
+		"v4l2"   : cv2.CAP_V4L2,
+		"vfwcap" : cv2.CAP_VFW
+	}
 	# Start video capture on the IR camera through OpenCV
-	video_capture = cv2.VideoCapture(config.get("video", "device_path"))
+	video_capture = cv2.VideoCapture(
+			config.get("video", "device_path"),
+			opencv_api_pref.get(config.get("video", "device_format"), cv2.CAP_V4L2)
+	)
 
 # Force MJPEG decoding if true
 if config.getboolean("video", "force_mjpeg", fallback=False):

--- a/src/config.ini
+++ b/src/config.ini
@@ -59,8 +59,8 @@ dark_threshold = 50
 # Switching from the default opencv to ffmpeg can help with grayscale issues.
 recording_plugin = opencv
 
-# Video format used by ffmpeg. Options include vfwcap or v4l2.
-# FFMPEG only.
+# Video format used by opencv/ffmpeg. Options include vfwcap or v4l2.
+# OPENCV and FFMPEG only.
 device_format = v4l2
 
 # Force the use of Motion JPEG when decoding frames, fixes issues with YUYV


### PR DESCRIPTION
Reopen of PR #155 in a new branch.  Outstanding issues still remain to be resolved.

TL;DR:

Fixes an issue I was getting with GStreamer:

```
anthony@demo:# G_DEBUG=fatal_warnings python compare.py username

(python:16551): GStreamer-CRITICAL **: 18:06:31.199: gst_element_get_state: assertion 'GST_IS_ELEMENT (element)' failed
[1]    16551 trace trap (core dumped)  G_DEBUG=fatal_warnings python -W error compare.py username
```

Unfortunately this PR introduced an issue whereby the tests broke, but to the best of my knowledge this is due to a limitation from the test suite. More details can be found in this comment [here](https://github.com/boltgolt/howdy/pull/155#issuecomment-467248976).