### PR TITLE
Add error message on camera read fail

### DIFF
--- a/src/cli/add.py
+++ b/src/cli/add.py
@@ -144,7 +144,19 @@ while frames < 60:
 	# Grab a single frame of video
 	# Don't remove ret, it doesn't work without it
 	ret, frame = video_capture.read()
-	gsframe = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+	if not ret:
+		print("Failed to read camera specified in your 'device_path', aborting")
+		sys.exit(1)
+
+	try:
+		# Convert from color to grayscale
+		# First processing of frame, so frame errors show up here
+		gsframe = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+	except RuntimeError:
+		gsframe = frame
+	except cv2.error:
+		print("\nUnknown camera, please check your 'device_path' config value.\n")
+		raise
 
 	# Create a histogram of the image with 8 values
 	hist = cv2.calcHist([gsframe], [0], None, [8], [0, 256])

--- a/src/cli/test.py
+++ b/src/cli/test.py
@@ -110,6 +110,9 @@ try:
 
 		# Grab a single frame of video
 		ret, frame = video_capture.read()
+		if not ret:
+			print("Failed to read camera specified in your 'device_path', aborting")
+			sys.exit(1)
 
 		try:
 			# Convert from color to grayscale

--- a/src/compare.py
+++ b/src/compare.py
@@ -183,9 +183,9 @@ while True:
 	# Grab a single frame of video
 	ret, frame = video_capture.read()
 
-	if frames == 1 and ret is False:
-		print("Could not read from camera")
-		exit(12)
+	if not ret:
+		print("Failed to read camera specified in your 'device_path', aborting")
+		sys.exit(1)
 
 	try:
 		# Convert from color to grayscale


### PR DESCRIPTION
**Edit: Please read #207 first, as that superseeds this PR.**

Lot's of people were a bit unclear (#160) as to what is going on when the `video_capture` fails to read anything.
This PR add's a simple error message in this case.