### PR TITLE
Fix missing colors in overlay

### DIFF
--- a/src/cli/test.py
+++ b/src/cli/test.py
@@ -124,6 +124,7 @@ try:
 		frame = clahe.apply(frame)
 		# Make a frame to put overlays in
 		overlay = frame.copy()
+		overlay = cv2.cvtColor(overlay, cv2.COLOR_GRAY2BGR)
 
 		# Fetch the frame height and width
 		height, width = frame.shape[:2]
@@ -190,6 +191,7 @@ try:
 
 		# Add the overlay to the frame with some transparency
 		alpha = 0.65
+		frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
 		cv2.addWeighted(overlay, alpha, frame, 1 - alpha, 0, frame)
 
 		# Show the image in a window


### PR DESCRIPTION
When running `howdy test` the overlay is shown in grayscale as `overlay` is a copy of `frame` which was already converted to grayscale.

This PR converts grayscale back to BGR after applying Contrast Limited Adaptive Histogram Equalization, and `frame` back to BGR before applying the overlay.