### PR TITLE
Apply CLAHE to frames in add.py and compare.py

### DIFF
--- a/src/cli/add.py
+++ b/src/cli/add.py
@@ -139,12 +139,15 @@ enc = []
 frames = 0
 dark_threshold = config.getfloat("video", "dark_threshold")
 
+clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+
 # Loop through frames till we hit a timeout
 while frames < 60:
 	# Grab a single frame of video
 	# Don't remove ret, it doesn't work without it
 	ret, frame = video_capture.read()
 	gsframe = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+	gsframe = clahe.apply(gsframe)
 
 	# Create a histogram of the image with 8 values
 	hist = cv2.calcHist([gsframe], [0], None, [8], [0, 256])

--- a/src/compare.py
+++ b/src/compare.py
@@ -172,6 +172,8 @@ end_report = config.getboolean("debug", "end_report")
 frames = 0
 timings["fr"] = time.time()
 
+clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+
 while True:
 	# Increment the frame count every loop
 	frames += 1
@@ -196,6 +198,8 @@ while True:
 	except cv2.error:
 		print("\nUnknown camera, please check your 'device_path' config value.\n")
 		raise
+
+	gsframe = clahe.apply(gsframe)	
 
 	# Create a histogram of the image with 8 values
 	hist = cv2.calcHist([gsframe], [0], None, [8], [0, 256])


### PR DESCRIPTION
Contrast Limited Adaptive History Equalization is not applied in `add.py` and `compare.py` before determining whether a frame is too dark. This leads to different behavior in classifying frame-darkness than what happens in `test.py`.

This should fix #275.