### PR TITLE
Fix fedora dependencies

### DIFF
--- a/fedora/howdy.spec
+++ b/fedora/howdy.spec
@@ -9,7 +9,7 @@ Version:        2.5.1
 %if %{with_snapshot}
 Release:	0.1.git.%{date}%{shortcommit}%{?dist}
 %else
-Release:	3%{?dist}
+Release:	4%{?dist}
 %endif
 Summary:        Windows Hello™ style authentication for Linux
 
@@ -27,10 +27,7 @@ BuildRequires:	polkit-devel
 %if 0%{?fedora}
 # We need python3-devel for pathfix.py
 BuildRequires:	python3-devel	
-Requires:       python3dist(dlib) >= 6.0
-Requires:	python3dist(v4l2)
-Requires:	python3-face_recognition
-Supplements:	python3-face_recognition_models
+Requires:	python3dist(dlib) >= 6.0
 Requires:	python3-opencv
 Requires:	pam_python
 %endif


### PR DESCRIPTION
- howdy uses by default opencv, so v4l2 isn't necessary.
- `python3-face_recognition` and `python3-face_recognition_models` aren't used any more.

v4l2 could be added as suggestion, but then ffmpeg and python-ffmpeg should be added as well.

Edit: missed the dev branch, rebased.