### PR TITLE
Add darkness threshold feedback

### DIFF
--- a/src/compare.py
+++ b/src/compare.py
@@ -66,6 +66,8 @@ user = sys.argv[1]
 models = []
 # Encoded face models
 encodings = []
+# Amount of ignored 100% black frames
+black_tries = 0
 # Amount of ingnored dark frames
 dark_tries = 0
 # Total amount of frames captured
@@ -170,7 +172,9 @@ end_report = config.getboolean("debug", "end_report")
 
 # Start the read loop
 frames = 0
+valid_frames = 0
 timings["fr"] = time.time()
+dark_running_total = 0
 
 while True:
 	# Increment the frame count every loop
@@ -178,6 +182,11 @@ while True:
 
 	# Stop if we've exceded the time limit
 	if time.time() - timings["fr"] > timeout:
+		average_darkness = dark_running_total / frames
+		if (dark_tries == valid_frames ):
+			print("All frames were too dark, please check dark_threshold in config")
+			print("Average darkness: " + str(dark_running_total / valid_frames) + ", Threshold: " + str(dark_threshold))
+			stop(13)
 		stop(11)
 
 	# Grab a single frame of video
@@ -202,9 +211,20 @@ while True:
 	# All values combined for percentage calculation
 	hist_total = np.sum(hist)
 
-	# If the image is fully black or the frame exceeds threshold,
+	# Calculate frame darkness
+	darkness = (hist[0] / hist_total * 100)
+
+	# If the image is fully black due to a bad camera read,
 	# skip to the next frame
-	if hist_total == 0 or (hist[0] / hist_total * 100 > dark_threshold):
+	if (hist_total == 0) or (darkness == 100):
+		black_tries += 1
+		continue
+
+	dark_running_total += darkness
+	valid_frames += 1
+	# If the image exceeds darkness threshold due to subject distance,
+	# skip to the next frame
+	if (darkness > dark_threshold):
 		dark_tries += 1
 		continue
 
@@ -263,6 +283,7 @@ while True:
 
 				# Show the total number of frames and calculate the FPS by deviding it by the total scan time
 				print("\nFrames searched: %d (%.2f fps)" % (frames, frames / timings["fr"]))
+				print("Black frames ignored: %d " % (black_tries, ))
 				print("Dark frames ignored: %d " % (dark_tries, ))
 				print("Certainty of winning frame: %.3f" % (match * 10, ))
 

--- a/src/compare.py
+++ b/src/compare.py
@@ -182,7 +182,6 @@ while True:
 
 	# Stop if we've exceded the time limit
 	if time.time() - timings["fr"] > timeout:
-		average_darkness = dark_running_total / frames
 		if (dark_tries == valid_frames ):
 			print("All frames were too dark, please check dark_threshold in config")
 			print("Average darkness: " + str(dark_running_total / valid_frames) + ", Threshold: " + str(dark_threshold))

--- a/src/pam.py
+++ b/src/pam.py
@@ -50,6 +50,10 @@ def doAuth(pamh):
 	# Status 12 means we aborted
 	elif status == 12:
 		return pamh.PAM_AUTH_ERR
+	# Status 13 means the image was too dark
+	elif status == 13:
+		pamh.conversation(pamh.Message(pamh.PAM_ERROR_MSG, "Face detection image too dark"))
+		return pamh.PAM_AUTH_ERR
 	# Status 0 is a successful exit
 	elif status == 0:
 		# Show the success message if it isn't suppressed


### PR DESCRIPTION
Allow Howdy to meaningfully distinguish between a registration or compare that failed due to insufficient lighting as opposed to bad camera reads or a facial recognition miss. Report this distinction to the user.

I found that properly tuning the dark_threshold config variable, or even knowing that it *needs* to be tuned, was exceedingly difficult, and this change provides the user with the feedback necessary to adjust dark_threshold appropriately.

In particular, on my Dell XPS 13 9300 integrated Windows Hello camera, I found that 100% of frames were being rejected as "too dark" before even being considered for face detection under the default settings, unless I situated myself in front of a wall. These changes assisted me in finding a working value for dark_threshold.