### PR TITLE
Fixes error with slow mode on low FPS

### DIFF
--- a/src/cli/test.py
+++ b/src/cli/test.py
@@ -183,7 +183,7 @@ try:
 
 		# Delay the frame if slowmode is on
 		if slow_mode:
-			time.sleep(.5 - frame_time)
+			time.sleep(max([.5 - frame_time, 0.0]))
 
 		if exposure != -1:
 			# For a strange reason on some cameras (e.g. Lenoxo X1E)


### PR DESCRIPTION
When frame_time exceeds 0.5 this change caps the sleep time to be at least zero, as trying to sleep a negative duration crashes the program.

Fixes, or at least is a work-around for #285