### PR TITLE
Fix negative sleep time error

### DIFF
--- a/src/cli/test.py
+++ b/src/cli/test.py
@@ -182,7 +182,7 @@ try:
 		frame_time = time.time() - frame_tm
 
 		# Delay the frame if slowmode is on
-		if slow_mode:
+		if slow_mode and (frame_time > .5):
 			time.sleep(.5 - frame_time)
 
 		if exposure != -1:


### PR DESCRIPTION
It's not clear to me in what circumstances this occurs, but on my machine at least in certain circumstances the test script errors with a traceback that indicates a negative sleep time was given.  This PR should fix that by just skipping the `sleep` call if this happens.