### PR TITLE
Stop verification and print warning if video device does not exist.

### DIFF
--- a/src/config.ini
+++ b/src/config.ini
@@ -40,6 +40,9 @@ timeout = 4
 # Should be set automatically by an installer if your distro has one
 device_path = none
 
+# Print a warning if the the video device is not found
+warn_no_device = true
+
 # Scale down the video feed to this maximum height
 # Speeds up face recognition but can make it less precise
 max_height = 320

--- a/src/pam.py
+++ b/src/pam.py
@@ -31,6 +31,12 @@ def doAuth(pamh):
 		if any("closed" in open(f).read() for f in glob.glob("/proc/acpi/button/lid/*/state")):
 			return pamh.PAM_AUTHINFO_UNAVAIL
 
+        # Abort if the video device does not exist
+        if not os.path.exists(config.get("video", "device_path")):
+                if config.getboolean("video", "warn_no_device"):
+                        print("Video device " + config.get("video", "device_path") + " not found")
+                return pamh.PAM_AUTHINFO_UNAVAIL
+
 	# Set up syslog
 	syslog.openlog("[HOWDY]", 0, syslog.LOG_AUTH)
 

--- a/src/pam.py
+++ b/src/pam.py
@@ -34,7 +34,7 @@ def doAuth(pamh):
         # Abort if the video device does not exist
         if not os.path.exists(config.get("video", "device_path")):
                 if config.getboolean("video", "warn_no_device"):
-                        print("Video device " + config.get("video", "device_path") + " not found")
+                        print("Camera path is not configured correctly, please edit the 'device_path' config value.")
                 return pamh.PAM_AUTHINFO_UNAVAIL
 
 	# Set up syslog

--- a/src/pam.py
+++ b/src/pam.py
@@ -31,7 +31,7 @@ def doAuth(pamh):
 		if any("closed" in open(f).read() for f in glob.glob("/proc/acpi/button/lid/*/state")):
 			return pamh.PAM_AUTHINFO_UNAVAIL
 
-        # Abort if the video device does not exist
+	# Abort if the video device does not exist
 	if not os.path.exists(config.get("video", "device_path")):
 		if config.getboolean("video", "warn_no_device"):
 			print("Camera path is not configured correctly, please edit the 'device_path' config value.")

--- a/src/pam.py
+++ b/src/pam.py
@@ -32,10 +32,10 @@ def doAuth(pamh):
 			return pamh.PAM_AUTHINFO_UNAVAIL
 
         # Abort if the video device does not exist
-        if not os.path.exists(config.get("video", "device_path")):
-                if config.getboolean("video", "warn_no_device"):
-                        print("Camera path is not configured correctly, please edit the 'device_path' config value.")
-                return pamh.PAM_AUTHINFO_UNAVAIL
+	if not os.path.exists(config.get("video", "device_path")):
+		if config.getboolean("video", "warn_no_device"):
+			print("Camera path is not configured correctly, please edit the 'device_path' config value.")
+		return pamh.PAM_AUTHINFO_UNAVAIL
 
 	# Set up syslog
 	syslog.openlog("[HOWDY]", 0, syslog.LOG_AUTH)


### PR DESCRIPTION
I have a laptop with a camera kill switch. When trying to verify with Howdy with the camera disabled, I get the following python error.
`Camera path is not configured correctly, please edit the 'device_path' config value.
Exception ignored in: <function VideoCapture.__del__ at 0x7fab7dca6ee0>
Traceback (most recent call last):
  File "/usr/lib/security/howdy/recorders/video_capture.py", line 55, in __del__
    self.internal.release()
AttributeError: 'VideoCapture' object has no attribute 'internal'
Unknown error: 1`

As I sometimes disable the camera, this gets annoying. This change makes only the useful warning `Camera path is not configured correctly, please edit the 'device_path' config value` show up, and gives an option, `warn_no_device` to silence the warning.