### PR TITLE
Add feature for test to also do recognition

### DIFF
--- a/src/cli/test.py
+++ b/src/cli/test.py
@@ -2,19 +2,28 @@
 
 # Import required modules
 import configparser
+import builtins
 import os
 import sys
 import time
 import dlib
 import cv2
+import json
 from recorders.video_capture import VideoCapture
+import numpy as np
 
 # Get the absolute path to the current file
-path = os.path.dirname(os.path.abspath(__file__))
+this_filepath = os.path.dirname(os.path.abspath(__file__))
+
+# set some things that can also be set via environment variables
+dlib_data_path = os.environ.get('DLIB_DATA_PATH', this_filepath + '/../dlib-data/')
+model_file_path = os.environ.get('FACEMODEL_FILE_PATH', this_filepath + "/../models/" + builtins.howdy_user + ".dat")
+config_file_path = os.environ.get('CONFIG_INI_PATH', this_filepath + "/../config.ini")
+show_all_matches = os.environ.get('SHOW_ALL_MATCHES', False)
 
 # Read config from disk
 config = configparser.ConfigParser()
-config.read(path + "/../config.ini")
+config.read(config_file_path)
 
 if config.get("video", "recording_plugin") != "opencv":
 	print("Howdy has been configured to use a recorder which doesn't support the test command yet")
@@ -54,10 +63,34 @@ use_cnn = config.getboolean('core', 'use_cnn', fallback=False)
 
 if use_cnn:
 	face_detector = dlib.cnn_face_detection_model_v1(
-		path + '/../dlib-data/mmod_human_face_detector.dat'
+		dlib_data_path + '/mmod_human_face_detector.dat'
 	)
 else:
 	face_detector = dlib.get_frontal_face_detector()
+
+#------------------
+# Try to load the face model from the models folder
+encodings = []
+try:
+	models = json.load(open(model_file_path))
+
+	for model in models:
+		encodings += model["data"]
+except FileNotFoundError:
+	print('No face model file found at path "%s".  Skipping model-fitting' % model_file_path)
+
+
+video_certainty = config.getfloat("video", "certainty", fallback=3.5) / 10
+
+# Start timing
+timings = {
+	"st": time.time()
+}
+#------------------
+
+# Start the others regardless
+pose_predictor = dlib.shape_predictor(dlib_data_path + "/shape_predictor_5_face_landmarks.dat")
+face_encoder = dlib.face_recognition_model_v1(dlib_data_path + "/dlib_face_recognition_resnet_model_v1.dat")
 
 clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
 
@@ -77,6 +110,7 @@ fps = 0
 sec = int(time.time())
 # recognition time
 rec_tm = 0
+lowest_certainty = match_index = -1  # (actually set below)
 
 # Wrap everything in an keyboard interupt handler
 try:
@@ -97,18 +131,18 @@ try:
 			sec_frames = 0
 
 		# Grab a single frame of video
-		_, frame = video_capture.read_frame()
+		ngsframe, gsframe = video_capture.read_frame()
 
-		frame = clahe.apply(frame)
-		# Make a frame to put overlays in
-		overlay = frame.copy()
+		gsframe = clahe.apply(gsframe)
+		# Make a gsframe to put overlays in
+		overlay = gsframe.copy()
 		overlay = cv2.cvtColor(overlay, cv2.COLOR_GRAY2BGR)
 
-		# Fetch the frame height and width
-		height, width = frame.shape[:2]
+		# Fetch the gsframe height and width
+		height, width = gsframe.shape[:2]
 
 		# Create a histogram of the image with 8 values
-		hist = cv2.calcHist([frame], [0], None, [8], [0, 256])
+		hist = cv2.calcHist([gsframe], [0], None, [8], [0, 256])
 		# All values combined for percentage calculation
 		hist_total = int(sum(hist)[0])
 		# Fill with the overal containing percentage
@@ -131,6 +165,8 @@ try:
 		print_text(1, "FPS: %d" % (fps, ))
 		print_text(2, "FRAMES: %d" % (total_frames, ))
 		print_text(3, "RECOGNITION: %dms" % (round(rec_tm * 1000), ))
+		if encodings:
+			print_text(4, "MATCH PROB: %d: %f" % (match_index, lowest_certainty))
 
 		# Show that slow mode is on, if it's on
 		if slow_mode:
@@ -147,11 +183,43 @@ try:
 			rec_tm = time.time()
 			# Get the locations of all faces and their locations
 			# Upsample it once
-			face_locations = face_detector(frame, 1)
+			face_locations = face_detector(gsframe, 1)
+
+			# Loop though all faces and try to ID them
+			lowest_certainty = 10 # Tracks the lowest certainty value in the loop
+			recognized = [] # True if face recognized, False if not
+			for loc in face_locations:
+				if use_cnn:
+					loc = loc.rect
+
+				if encodings:
+					#Try to recognize
+					# Fetch the faces in the image
+					face_landmark = pose_predictor(ngsframe, loc)
+					face_encoding = np.array(face_encoder.compute_face_descriptor(ngsframe, face_landmark, 1))
+
+					# Match this found face against a known face
+					matches = np.linalg.norm(encodings - face_encoding, axis=1)
+
+					# Get best match
+					match_index = np.argmin(matches)
+					match = matches[match_index]
+					if show_all_matches:
+						print('All Matches', matches)
+
+					# Update certainty if we have a new low
+					if lowest_certainty > match:
+						lowest_certainty = match
+
+					# Check if a match that's confident enough
+					recognized.append(0 < match < video_certainty)
+				else:
+					recognized.append(False)
+
 			rec_tm = time.time() - rec_tm
 
 			# Loop though all faces and paint a circle around them
-			for loc in face_locations:
+			for i, loc in enumerate(face_locations):
 				if use_cnn:
 					loc = loc.rect
 
@@ -164,12 +232,17 @@ try:
 				# Add 20% padding
 				r = int(r + (r * 0.2))
 
-				# Draw the Circle in green
-				cv2.circle(overlay, (x, y), r, (0, 0, 230), 2)
+				# Draw the Circle in green if recognized, red if not.
+				if recognized[i]:
+					color = (0, 230, 0)
+				else:
+					color = (0, 0, 230)
+				cv2.circle(overlay, (x, y), r, color, 2)
+
 
 		# Add the overlay to the frame with some transparency
 		alpha = 0.65
-		frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
+		frame = cv2.cvtColor(gsframe, cv2.COLOR_GRAY2BGR)
 		cv2.addWeighted(overlay, alpha, frame, 1 - alpha, 0, frame)
 
 		# Show the image in a window


### PR DESCRIPTION
To try to troubleshoot some lack-of-recognition problems I was having, I updated the test cli script to add a stage where it does face model comparison.

Two things I wasn't sure of in this implementation:
1. Because  `compare.py` isn't in a "real" python package, there's no straightforward way I could work out to use it directly in the "test" script.  So I had to copy-and-paste, which is problematic if the `compare.py` changes down the line.
2. There are now several parameters to the test command, but I didn't see an obvious way to pass thos in from `cli.py` with the way this is architected.  So I did environment variables.  Can change that if there's a desired idiom other than that, though.