### PR TITLE
Changed final print statement to reflect changes

### DIFF
--- a/src/cli/disable.py
+++ b/src/cli/disable.py
@@ -39,7 +39,7 @@ for line in fileinput.input([config_path], inplace=1):
 	print(line.replace("disabled = " + config.get("core", "disabled"), "disabled = " + out_value), end="")
 
 # Print what we just did
-if builtins.howdy_args.argument == "1":
+if out_value == "true":
 	print("Howdy has been disabled")
 else:
 	print("Howdy has been enabled")


### PR DESCRIPTION
Arguments for the `disable` command are either `{0, false}`, or `{1, true}`. However, only if the argument is `1` will the print statement print "Howdy has been disabled". It should, by right, also show if the argument was `true`. To fix it, I noticed that the 2 possible sets of arguments fall into either of 2 groups characterised by the variable `out_value`. I thus suggest that the variable be used in the conditional for the final print statement.