### PR TITLE
Update PKGBUILD

### DIFF
--- a/archlinux/pam-python/PKGBUILD
+++ b/archlinux/pam-python/PKGBUILD
@@ -9,7 +9,7 @@ url="https://github.com/boltgolt/howdy"
 license=('MIT')
 depends=(
   'pam'
-  'python2'
+  'python'
 )
 makedepends=(
   'python-sphinx'


### PR DESCRIPTION
Python2 is not needed anymore. Python (e.g. Python3 will suffice)
See issue #501