### PR TITLE
Add python-opencv as a dependency for ArchLinux

### DIFF
--- a/archlinux/howdy/.SRCINFO
+++ b/archlinux/howdy/.SRCINFO
@@ -13,6 +13,7 @@ pkgbase = howdy
 	depends = python3
 	depends = python-dlib
 	depends = python-numpy
+	depends = python-opencv
 	backup = usr/lib/security/howdy/config.ini
 	source = howdy-2.6.1.tar.gz::https://github.com/boltgolt/howdy/archive/v2.6.1.tar.gz
 	source = https://github.com/davisking/dlib-models/raw/master/dlib_face_recognition_resnet_model_v1.dat.bz2


### PR DESCRIPTION
In the AUR package details [GJRodenburg noted the following](https://aur.archlinux.org/packages/howdy/#comment-800292):

> Opencv has split of it's python parts since opencv 4.5.2-2, they are now available as python-opencv. This will need to be included as a dependency of Howdy.

Confirmed locally following an update that howdy was failing with:

```
Traceback (most recent call last):
  File "/lib/security/howdy/compare.py", line 18, in <module>
    import cv2
ModuleNotFoundError: No module named 'cv2'
Unknown error: 1
```

Following installation of [python-opencv](https://aur.archlinux.org/packages/python-opencv) howdy worked as expected.