### PR TITLE
Use os.geteuid instead of env SUDO_USER to determine if running as root

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -80,7 +80,7 @@ builtins.howdy_user = args.user
 
 # Check if we have rootish rights
 # This is this far down the file so running the command for help is always possible
-if os.getenv("SUDO_USER") is None:
+if os.geteuid() == 0:
 	print("Please run this command as root:\n")
 	print("\tsudo howdy " + " ".join(sys.argv[1:]))
 	sys.exit(1)


### PR DESCRIPTION
Fixes #387 

This will still detect the usage of sudo, but also of other tools like su, pkexec (or the rare case when users really log in and run applications as root …)