### PR TITLE
Update PKGBUILD to add python-opencv

### DIFF
--- a/archlinux/howdy/.SRCINFO
+++ b/archlinux/howdy/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = howdy
 	pkgdesc = Windows Hello for Linux
 	pkgver = 2.6.1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/boltgolt/howdy
 	arch = x86_64
 	license = MIT

--- a/archlinux/howdy/PKGBUILD
+++ b/archlinux/howdy/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=howdy
 pkgver=2.6.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Windows Hello for Linux"
 arch=('x86_64')
 url="https://github.com/boltgolt/howdy"

--- a/archlinux/howdy/PKGBUILD
+++ b/archlinux/howdy/PKGBUILD
@@ -17,6 +17,7 @@ depends=(
 	'python3'
 	'python-dlib'
 	'python-numpy'
+	'python-opencv'
 )
 makedepends=(
 	'cmake'


### PR DESCRIPTION
The previous PR #528 adds `python-opencv` as a dependency, but (erroneously) only in `.SRCINFO`. That is not right, it needs to be added to `PKGBUILD`.

BTW, `.SRCINFO` probably should not be checked in to the interface as it's meant to be generated from `PKGBUILD`. It is only used by the AUR interface to correctly display dependencies, etc.