### PR TITLE
rename wrong attribute name to prevent AttributeError Python Exception

### DIFF
--- a/src/cli/test.py
+++ b/src/cli/test.py
@@ -192,8 +192,8 @@ try:
 			# are captured and even after a delay it does not
 			# always work. Setting exposure at every frame is
 			# reliable though.
-			video_capture.intenal.set(cv2.CAP_PROP_AUTO_EXPOSURE, 1.0)  # 1 = Manual
-			video_capture.intenal.set(cv2.CAP_PROP_EXPOSURE, float(exposure))
+			video_capture.internal.set(cv2.CAP_PROP_AUTO_EXPOSURE, 1.0)  # 1 = Manual
+			video_capture.internal.set(cv2.CAP_PROP_EXPOSURE, float(exposure))
 
 # On ctrl+C
 except KeyboardInterrupt:


### PR DESCRIPTION
according to https://github.com/boltgolt/howdy/issues/671

also pls applied on both beta/dev branch