### PR TITLE
Fix Fedora Polkit

### DIFF
--- a/src/pam.py
+++ b/src/pam.py
@@ -41,7 +41,7 @@ def doAuth(pamh):
 	syslog.syslog(syslog.LOG_INFO, "Attempting facial authentication for user " + pamh.get_user())
 
 	# Run compare as python3 subprocess to circumvent python version and import issues
-	status = subprocess.call(["/usr/bin/python3", os.path.dirname(os.path.abspath(__file__)) + "/compare.py", pamh.get_user()])
+	status = subprocess.call(["/usr/bin/python3 " + os.path.dirname(os.path.abspath(__file__)) + "/compare.py " + pamh.get_user() + " &> /dev/null"], shell=True)
 
 	# Status 10 means we couldn't find any face models
 	if status == 10:


### PR DESCRIPTION
This is a fix for the issue https://github.com/boltgolt/howdy/issues/630

If think that on Fedora, polkit detect that the subprocess `compare.py` is created and to avoid security issue it is killed. 
However, if we run this subprocess through a shell instance, this is no more a problem.
So this fix is not really clean, but it works. 

In order to provide a proper solution, I think we need to investigate polkit to create a policy or something like that. But personally, I don't know anything about it, and this seems complex. It is also possible that there is no such thing and that it is simply a bug.

---
I made the modification from the tag of the current version of Howdy: v2.6.1.

In order to provide this fix for Fedora users we have several choices:

* An official version of Howdy 2.6.2 is created
* The Fedora's repo maintainer creates a "hot fix", but we keep the v2.6.1 tag as source. The version on Fedora would become 2.6.1-7 (currently 2.6.1-6)
* I create a tag on the `fedora-polkit` branch of my fork, which is temporarily used as source. The version on Fedora would become 2.6.1-7
* We do nothing for Fedora at the moment, and we wait for the next official release, the v3.0.0, which rewrites the pam module in C++
