### PR TITLE
Update Debian build files

### DIFF
--- a/howdy/debian/control
+++ b/howdy/debian/control
@@ -2,7 +2,7 @@ Source: howdy
 Section: misc
 Priority: optional
 Standards-Version: 3.9.7
-Build-Depends: python, devscripts, dh-make, debhelper, fakeroot, python3, python3-pip, python3-setuptools, python3-wheel, ninja-build, meson, libpam0g-dev, libboost-all-dev
+Build-Depends: devscripts, dh-make, debhelper, fakeroot, python3, python3-pip, python3-setuptools, python3-wheel, ninja-build, meson, libpam0g-dev, libinih-dev, libevdev-dev
 Maintainer: boltgolt <boltgolt@gmail.com>
 Vcs-Git: https://github.com/boltgolt/howdy
 

--- a/howdy/debian/install
+++ b/howdy/debian/install
@@ -1,6 +1,6 @@
 src/cli/. lib/security/howdy/cli
 src/dlib-data/. lib/security/howdy/dlib-data
-src/locales/. lib/security/howdy/locales
+# src/locales/. lib/security/howdy/locales
 src/recorders/. lib/security/howdy/recorders
 src/rubberstamps/. lib/security/howdy/rubberstamps
 src/cli.py lib/security/howdy
@@ -13,4 +13,4 @@ src/snapshot.py lib/security/howdy
 
 src/autocomplete/. usr/share/bash-completion/completions
 src/pam-config/.  /usr/share/pam-configs
-build/libpam_howdy.so lib/security/howdy
+build/pam_howdy.so lib/security/howdy

--- a/howdy/debian/rules
+++ b/howdy/debian/rules
@@ -11,7 +11,7 @@ build:
 	# Create build dir
 	meson setup -Dinih:with_INIReader=true build src/pam
 	# Compile shared object
-	meson install -C build
+	ninja -C build
 
 clean:
 	# Delete mason build directory

--- a/howdy/debian/rules
+++ b/howdy/debian/rules
@@ -11,12 +11,10 @@ build:
 	# Create build dir
 	meson setup -Dinih:with_INIReader=true build src/pam
 	# Compile shared object
-	meson compile -C build
+	meson install -C build
 
 clean:
 	# Delete mason build directory
 	rm -rf ./build
 	# Force remove temp debian build directory
 	rm -rf ./debian/howdy
-	# Make sure subprojects get pulled locally
-	meson subprojects download --sourcedir src/pam


### PR DESCRIPTION
Add the necessary build dependencies and remove deprecated python requirement.
Also use `install` instead of `compile` for meson command, since the version shipped with Ubuntu 20.04 doesn't support it.
Not sure about the locales though, should we keep them?