### PR TITLE
Add python3 pam-python support

### DIFF
--- a/howdy/src/pam.py
+++ b/howdy/src/pam.py
@@ -4,13 +4,17 @@
 import subprocess
 import os
 import glob
+import sys
 import syslog
 
-# pam-python is running python 2, so we use the old module here
-import ConfigParser
+if sys.version_info.major < 3:
+    import ConfigParser
+    config = ConfigParser.ConfigParser()
+else:
+    import configparser
+    config = configparser.ConfigParser()
 
 # Read config from disk
-config = ConfigParser.ConfigParser()
 config.read(os.path.dirname(os.path.abspath(__file__)) + "/config.ini")
 
 


### PR DESCRIPTION
Hi,
As a pam-python based on python3 is available on Archlinux (https://aur.archlinux.org/packages/pam-python-git, based on https://github.com/castlabs/pam-python), howdy need to import good configparser module.