### PR TITLE
Add python3 pam-python support

### DIFF
--- a/src/pam.py
+++ b/src/pam.py
@@ -4,13 +4,17 @@
 import subprocess
 import os
 import glob
+import sys
 import syslog
 
-# pam-python is running python 2, so we use the old module here
-import ConfigParser
+if sys.version_info.major < 3:
+    import ConfigParser
+    config = ConfigParser.ConfigParser()
+else:
+    import configparser
+    config = configparser.ConfigParser()
 
 # Read config from disk
-config = ConfigParser.ConfigParser()
 config.read(os.path.dirname(os.path.abspath(__file__)) + "/config.ini")
 
 


### PR DESCRIPTION
As in https://github.com/boltgolt/howdy/pull/709 I don't use the good branch, this is another attempt to use pam-python based on python3... With the good branch :-)
Tested on Archlinux.