### PR TITLE
config: add fallbacks

### DIFF
--- a/howdy-gtk/src/tab_video.py
+++ b/howdy-gtk/src/tab_video.py
@@ -44,7 +44,7 @@ def on_page_switch(self, notebook, page, page_num):
 		if width * self.scaling_factor > MAX_WIDTH:
 			self.scaling_factor = (MAX_WIDTH / width) or 1
 
-		config_height = self.config.getfloat("video", "max_height", fallback=0.0)
+		config_height = self.config.getfloat("video", "max_height", fallback=320.0)
 		config_scaling = (config_height / height) or 1
 
 		self.builder.get_object("videoid").set_text(path.split("/")[-1])

--- a/howdy/src/cli/add.py
+++ b/howdy/src/cli/add.py
@@ -131,7 +131,7 @@ dark_tries = 0
 dark_running_total = 0
 face_locations = None
 
-dark_threshold = config.getfloat("video", "dark_threshold")
+dark_threshold = config.getfloat("video", "dark_threshold", fallback=60)
 
 clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
 

--- a/howdy/src/cli/disable.py
+++ b/howdy/src/cli/disable.py
@@ -35,13 +35,13 @@ else:
 	sys.exit(1)
 
 # Don't do anything when the state is already the requested one
-if out_value == config.get("core", "disabled"):
+if out_value == config.get("core", "disabled", fallback=True):
 	print(_("The disable option has already been set to ") + out_value)
 	sys.exit(1)
 
 # Loop though the config file and only replace the line containing the disable config
 for line in fileinput.input([config_path], inplace=1):
-	print(line.replace("disabled = " + config.get("core", "disabled"), "disabled = " + out_value), end="")
+	print(line.replace("disabled = " + config.get("core", "disabled", fallback=True), "disabled = " + out_value), end="")
 
 # Print what we just did
 if out_value == "true":

--- a/howdy/src/cli/snap.py
+++ b/howdy/src/cli/snap.py
@@ -23,7 +23,7 @@ video_capture.read_frame()
 
 # Read exposure and dark_thresholds from config to use in the main loop
 exposure = config.getint("video", "exposure", fallback=-1)
-dark_threshold = config.getfloat("video", "dark_threshold")
+dark_threshold = config.getfloat("video", "dark_threshold", fallback=60)
 
 # COllection of recorded frames
 frames = []
@@ -43,7 +43,7 @@ while True:
 file = snapshot.generate(frames, [
 	_("GENERATED SNAPSHOT"),
 	_("Date: ") + datetime.datetime.utcnow().strftime("%Y/%m/%d %H:%M:%S UTC"),
-	_("Dark threshold config: ") + str(config.getfloat("video", "dark_threshold", fallback=50.0)),
+	_("Dark threshold config: ") + str(config.getfloat("video", "dark_threshold", fallback=60.0)),
 	_("Certainty config: ") + str(config.getfloat("video", "certainty", fallback=3.5))
 ])
 

--- a/howdy/src/cli/test.py
+++ b/howdy/src/cli/test.py
@@ -21,7 +21,7 @@ path = "/etc/howdy"
 config = configparser.ConfigParser()
 config.read(path + "/config.ini")
 
-if config.get("video", "recording_plugin") != "opencv":
+if config.get("video", "recording_plugin", fallback="opencv") != "opencv":
 	print(_("Howdy has been configured to use a recorder which doesn't support the test command yet, aborting"))
 	sys.exit(12)
 
@@ -30,7 +30,7 @@ video_capture = VideoCapture(config)
 # Read config values to use in the main loop
 video_certainty = config.getfloat("video", "certainty", fallback=3.5) / 10
 exposure = config.getint("video", "exposure", fallback=-1)
-dark_threshold = config.getfloat("video", "dark_threshold")
+dark_threshold = config.getfloat("video", "dark_threshold", fallback=60)
 
 # Let the user know what's up
 print(_("""

--- a/howdy/src/compare.py
+++ b/howdy/src/compare.py
@@ -146,7 +146,7 @@ config.read(PATH + "/config.ini")
 
 # Get all config values needed
 use_cnn = config.getboolean("core", "use_cnn", fallback=False)
-timeout = config.getint("video", "timeout", fallback=5)
+timeout = config.getint("video", "timeout", fallback=4)
 dark_threshold = config.getfloat("video", "dark_threshold", fallback=50.0)
 video_certainty = config.getfloat("video", "certainty", fallback=3.5) / 10
 end_report = config.getboolean("debug", "end_report", fallback=False)
@@ -196,7 +196,7 @@ lock.release()
 del lock
 
 # Fetch the max frame height
-max_height = config.getfloat("video", "max_height", fallback=0.0)
+max_height = config.getfloat("video", "max_height", fallback=320.0)
 
 # Get the height of the image (which would be the width if screen is portrait oriented)
 height = video_capture.internal.get(cv2.CAP_PROP_FRAME_HEIGHT) or 1
@@ -206,9 +206,9 @@ if rotate == 2:
 scaling_factor = (max_height / height) or 1
 
 # Fetch config settings out of the loop
-timeout = config.getint("video", "timeout")
-dark_threshold = config.getfloat("video", "dark_threshold")
-end_report = config.getboolean("debug", "end_report")
+timeout = config.getint("video", "timeout", fallback=4)
+dark_threshold = config.getfloat("video", "dark_threshold", fallback=60)
+end_report = config.getboolean("debug", "end_report", fallback=False)
 
 # Initiate histogram equalization
 clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))

--- a/howdy/src/recorders/video_capture.py
+++ b/howdy/src/recorders/video_capture.py
@@ -33,7 +33,7 @@ class VideoCapture:
 
 		# Check device path
 		if not os.path.exists(self.config.get("video", "device_path")):
-			if self.config.getboolean("video", "warn_no_device"):
+			if self.config.getboolean("video", "warn_no_device", fallback=True):
 				print(_("Howdy could not find a camera device at the path specified in the config file."))
 				print(_("It is very likely that the path is not configured correctly, please edit the 'device_path' config value by running:"))
 				print("\n\tsudo howdy config\n")
@@ -100,21 +100,22 @@ class VideoCapture:
 		"""
 		Sets up the video reader instance
 		"""
+		recording_plugin = self.config.get("video", "recording_plugin", fallback="opencv")
 
-		if self.config.get("video", "recording_plugin") == "ffmpeg":
+		if recording_plugin == "ffmpeg":
 			# Set the capture source for ffmpeg
 			from recorders.ffmpeg_reader import ffmpeg_reader
 			self.internal = ffmpeg_reader(
 				self.config.get("video", "device_path"),
-				self.config.get("video", "device_format")
+				self.config.get("video", "device_format", fallback="v4l2")
 			)
 
-		elif self.config.get("video", "recording_plugin") == "pyv4l2":
+		elif recording_plugin == "pyv4l2":
 			# Set the capture source for pyv4l2
 			from recorders.pyv4l2_reader import pyv4l2_reader
 			self.internal = pyv4l2_reader(
 				self.config.get("video", "device_path"),
-				self.config.get("video", "device_format")
+				self.config.get("video", "device_format", fallback="v4l2")
 			)
 
 		else:


### PR DESCRIPTION
Add missing fallbacks for config options, based on values in `config.ini`.
This allows using a config file where only some of the keys are set.
Fixes #761.

Untested, will add an edit once I've finished testing.
EDIT: auth seems to be working everywhere except `swaylock`. However, if a file with every key set is present, it will work properly.