### PR TITLE
Adding missing `v4l-utils` package to Ubuntu dependencies

### DIFF
--- a/howdy/debian/control
+++ b/howdy/debian/control
@@ -9,8 +9,8 @@ Vcs-Git: https://github.com/boltgolt/howdy
 Package: howdy
 Homepage: https://github.com/boltgolt/howdy
 Architecture: amd64
-Depends: ${misc:Depends}, libc6, libgcc-s1, libpam0g, libstdc++6, curl | wget, python3, python3-pip, python3-dev, python3-setuptools, python3-numpy, python-opencv | python3-opencv, libopencv-dev, cmake, libinih-dev, v4l-utils
-Recommends: libatlas-base-dev | libopenblas-dev | liblapack-dev, howdy-gtk
+Depends: ${misc:Depends}, libc6, libgcc-s1, libpam0g, libstdc++6, curl | wget, python3, python3-pip, python3-dev, python3-setuptools, python3-numpy, python-opencv | python3-opencv, libopencv-dev, cmake, libinih-dev
+Recommends: libatlas-base-dev | libopenblas-dev | liblapack-dev, howdy-gtk, v4l-utils
 Suggests: nvidia-cuda-dev (>= 7.5)
 Description: Howdy: Windows Hello style authentication for Linux.
  Use your built-in IR emitters and camera in combination with face recognition

--- a/howdy/debian/control
+++ b/howdy/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: https://github.com/boltgolt/howdy
 Package: howdy
 Homepage: https://github.com/boltgolt/howdy
 Architecture: amd64
-Depends: ${misc:Depends}, libc6, libgcc-s1, libpam0g, libstdc++6, curl | wget, python3, python3-pip, python3-dev, python3-setuptools, python3-numpy, python-opencv | python3-opencv, libopencv-dev, cmake, libinih-dev
+Depends: ${misc:Depends}, libc6, libgcc-s1, libpam0g, libstdc++6, curl | wget, python3, python3-pip, python3-dev, python3-setuptools, python3-numpy, python-opencv | python3-opencv, libopencv-dev, cmake, libinih-dev, v4l-utils
 Recommends: libatlas-base-dev | libopenblas-dev | liblapack-dev, howdy-gtk
 Suggests: nvidia-cuda-dev (>= 7.5)
 Description: Howdy: Windows Hello style authentication for Linux.


### PR DESCRIPTION
Howdy missed my camera device during install because the setup process relies on `v4l`, which was not installed.