### PR TITLE
Fix some bugs

### DIFF
--- a/howdy/debian/preinst
+++ b/howdy/debian/preinst
@@ -4,6 +4,7 @@
 
 import subprocess
 import sys
+import os
 
 # Backup the config file if we're upgrading
 if "upgrade" in sys.argv:

--- a/howdy/src/cli/disable.py
+++ b/howdy/src/cli/disable.py
@@ -10,7 +10,7 @@ import configparser
 from i18n import _
 
 # Get the absolute filepath
-config_path = os.path.dirname("/etc/howdy") + "/config.ini"
+config_path = os.path.dirname("/etc/howdy/") + "/config.ini"
 
 # Read config from disk
 config = configparser.ConfigParser()

--- a/howdy/src/cli/set.py
+++ b/howdy/src/cli/set.py
@@ -9,7 +9,7 @@ import fileinput
 from i18n import _
 
 # Get the absolute filepath
-config_path = os.path.dirname("/etc/howdy") + "/config.ini"
+config_path = os.path.dirname("/etc/howdy/") + "/config.ini"
 
 # Check if enough arguments have been passed
 if len(builtins.howdy_args.arguments) < 2:


### PR DESCRIPTION
I found it doesn't import the os module in preinst script, thus I fixed it.
While I installed the beta version pack and run `howdy disable 1`, I got a `FileNotFoundError` because the lacking of slash while calling function `os.path.dirname`. I don't know if it is a bug. But after this commit I can run it properly.