### PR TITLE
Add configurable device frame rate

### DIFF
--- a/howdy/src/config.ini
+++ b/howdy/src/config.ini
@@ -86,6 +86,12 @@ force_mjpeg = false
 # OPENCV only.
 exposure = -1
 
+# Specify frame rate of the capture device.
+# Some IR emitters will not function properly at the default framerate.
+# Use qv4l2 to determine an appropriate value.
+# OPENCV only.
+device_fps = -1
+
 # Rotate captured frames so faces are upright.
 #  0  Check landscape orientation only
 #  1  Check both landscape and portrait orientation

--- a/howdy/src/recorders/video_capture.py
+++ b/howdy/src/recorders/video_capture.py
@@ -124,6 +124,12 @@ class VideoCapture:
 				self.config.get("video", "device_path"),
 				cv2.CAP_V4L
 			)
+			# Set the capture frame rate
+			# Without this the first detected (and possibly lower) frame rate is used, -1 seems to select the highest
+			# Use 0 as a fallback to avoid breaking an existing setup, new installs should default to -1
+			self.fps = self.config.getint("video", "device_fps", fallback=0)
+			if self.fps != 0:
+				self.internal.set(cv2.CAP_PROP_FPS, self.fps)
 
 		# Force MJPEG decoding if true
 		if self.config.getboolean("video", "force_mjpeg", fallback=False):


### PR DESCRIPTION
Currently OpenCV defaults to the first detected (and sometimes lowest) frame rate. This is bad enough for detection on its own, but some IR emitters do not function properly at all frame rates the camera may support (like my surface laptop studio). I've added a device_fps option to the config to set this manually, as well as use the highest frame rate by default on new installs.