### PR TITLE
Add option to make howdy inactive during night (dark)

### DIFF
--- a/howdy/src/compare.py
+++ b/howdy/src/compare.py
@@ -300,6 +300,11 @@ while True:
 	# Calculate frame darkness
 	darkness = (hist[0] / hist_total * 100)
 
+	# Stop if dark hour
+	if darkness > dark_threshold and dark_inactive_now and frames == 1:
+		syslog.syslog(syslog.LOG_INFO, "Aborted authentication, dark hour detected")
+		exit(13)
+
 	# If the image is fully black due to a bad camera read,
 	# skip to the next frame
 	if (hist_total == 0) or (darkness == 100):
@@ -313,10 +318,6 @@ while True:
 	# skip to the next frame
 	if (darkness > dark_threshold):
 		dark_tries += 1
-		# Stop if dark hour
-		if dark_inactive_now and frames == 1:
-			syslog.syslog(syslog.LOG_INFO, "Aborted authentication, dark hour detected")
-			exit(13)
 		continue
 
 	# If the height is too high

--- a/howdy/src/config.ini
+++ b/howdy/src/config.ini
@@ -25,6 +25,15 @@ abort_if_lid_closed = true
 # The howdy command will still function
 disabled = false
 
+# Disable howdy for night (dark):
+# off - active always, dark_hours ignored
+# camera - active but if first frame is dark and time in dark_hours inactive
+# on - active except for dark_hours
+dark_inactive = off
+
+# Hours to disable for (format HH:MM-HH:MM)
+dark_hours = HH:MM-HH:MM
+
 # Use CNN instead of HOG
 # CNN model is much more accurate than the HOG based model, but takes much more
 # power to run, and is meant to be executed on a GPU to attain reasonable speed.

--- a/howdy/src/pam/main.cc
+++ b/howdy/src/pam/main.cc
@@ -173,7 +173,7 @@ auto check_enabled(const INIReader &config) -> int {
 
     // Stop if dark hour
     if ((dark_start <= dark_end && dark_start <= local_minutes && local_minutes <= dark_end)
-     || (dark_start <= local_minutes || local_minutes <= dark_end)) {
+    || (dark_start > dark_end && (dark_start <= local_minutes || local_minutes <= dark_end)) {
       syslog(LOG_INFO, "Skipped authentication, dark hour");
       return PAM_AUTHINFO_UNAVAIL;
     }


### PR DESCRIPTION
I added option which will make howdy inactive during night (on specified hours in pam module and on detection in compare.py). This will allow users to not have to wait for howdy timeout when there is no way howdy would work.