### PR TITLE
Use subdirs for 'py_sources_dir' too

### DIFF
--- a/howdy-gtk/meson.build
+++ b/howdy-gtk/meson.build
@@ -32,7 +32,7 @@ py.dependency()
 if get_option('install_in_site_packages')
     pysourcesinstalldir = join_paths(py.get_install_dir(), 'howdy-gtk')
 else
-    pysourcesinstalldir = get_option('py_sources_dir') != '' ? get_option('py_sources_dir') : join_paths(get_option('prefix'), get_option('libdir'), 'howdy-gtk')
+    pysourcesinstalldir = get_option('py_sources_dir') != '' ? get_option('py_sources_dir') / 'howdy-gtk' : join_paths(get_option('prefix'), get_option('libdir'), 'howdy-gtk')
 endif
 
 if get_option('install_in_site_packages')

--- a/howdy/src/meson.build
+++ b/howdy/src/meson.build
@@ -46,7 +46,7 @@ py_sources = [
 if get_option('install_in_site_packages')
     pysourcesinstalldir = join_paths(py.get_install_dir(), 'howdy')
 else  
-    pysourcesinstalldir = get_option('py_sources_dir') != '' ? get_option('py_sources_dir') : join_paths(get_option('prefix'), get_option('libdir'), 'howdy')
+    pysourcesinstalldir = get_option('py_sources_dir') != '' ? get_option('py_sources_dir') / 'howdy' : join_paths(get_option('prefix'), get_option('libdir'), 'howdy')
 endif
 
 pam_module_conf_data = configuration_data(paths_dict)


### PR DESCRIPTION
If you explicitly specify the `py_sources_dir` option, the howdy and howdy-gtk source files get mixed up, fixed that.
