### PR TITLE
Add Python 3 PAM compatibility

### DIFF
--- a/src/pam.py
+++ b/src/pam.py
@@ -4,13 +4,16 @@
 import subprocess
 import os
 import glob
+import sys
 import syslog
 
-# pam-python is running python 2, so we use the old module here
-import ConfigParser
+if sys.version_info >= (3,):
+	import configparser
+else:
+	import ConfigParser as configparser
 
 # Read config from disk
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(os.path.dirname(os.path.abspath(__file__)) + "/config.ini")
 
 


### PR DESCRIPTION
Fix the following error from /var/log/auth.log:
/lib/security/howdy/pam.py[6883]:   File "/lib/security/howdy/pam.py", line 13, in <module>
/lib/security/howdy/pam.py[6883]:     config = ConfigParser.ConfigParser()

Targetting master instead dev because this is a fix for older releases of howdy.