### PR TITLE
Connect to signals of the shown window

### DIFF
--- a/howdy-gtk/src/onboarding.py
+++ b/howdy-gtk/src/onboarding.py
@@ -19,15 +19,15 @@ class OnboardingWindow(gtk.Window):
 		# Make the class a GTK window
 		gtk.Window.__init__(self)
 
-		self.connect("destroy", self.exit)
-		self.connect("delete_event", self.exit)
-
 		self.builder = gtk.Builder()
 		self.builder.add_from_file(paths_factory.onboarding_wireframe_path())
 		self.builder.connect_signals(self)
 
 		self.window = self.builder.get_object("onboardingwindow")
 		self.nextbutton = self.builder.get_object("nextbutton")
+
+		self.window.connect("destroy", self.exit)
+		self.window.connect("delete_event", self.exit)
 
 		self.slides = [
 			self.builder.get_object("slide0"),
@@ -317,7 +317,7 @@ class OnboardingWindow(gtk.Window):
 		dialog.destroy()
 		self.exit()
 
-	def exit(self, widget=None):
+	def exit(self, widget=None, context=None):
 		"""Cleanly exit"""
 		gtk.main_quit()
 		sys.exit(0)

--- a/howdy-gtk/src/window.py
+++ b/howdy-gtk/src/window.py
@@ -23,9 +23,6 @@ class MainWindow(gtk.Window):
 		# Make the class a GTK window
 		gtk.Window.__init__(self)
 
-		self.connect("destroy", self.exit)
-		self.connect("delete_event", self.exit)
-
 		self.builder = gtk.Builder()
 		self.builder.add_from_file(paths_factory.main_window_wireframe_path())
 		self.builder.connect_signals(self)
@@ -34,6 +31,9 @@ class MainWindow(gtk.Window):
 		self.userlist = self.builder.get_object("userlist")
 		self.modellistbox = self.builder.get_object("modellistbox")
 		self.opencvimage = self.builder.get_object("opencvimage")
+
+		self.window.connect("destroy", self.exit)
+		self.window.connect("delete_event", self.exit)
 
 		# Init capture for video tab
 		self.capture = None
@@ -105,7 +105,7 @@ class MainWindow(gtk.Window):
 		status, output = subprocess.getstatusoutput(["sudo -u " + user + " timeout 10 xdg-open " + uri])
 		return True
 
-	def exit(self, widget, context):
+	def exit(self, widget=None, context=None):
 		"""Cleanly exit"""
 		if self.capture is not None:
 			self.capture.release()


### PR DESCRIPTION
In the case of `OnboardingWindow` and `MainWindow`, the class itself is not shown as a window, but its `window` field is shown, so when the window is closed, the application does not terminate - the wrong signals is connected to the handler.