### PR TITLE
Fix things regarding translations

### DIFF
--- a/howdy-gtk/src/main.glade
+++ b/howdy-gtk/src/main.glade
@@ -137,7 +137,7 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="addbutton">
-                    <property name="label">Add</property>
+                    <property name="label" translatable="yes">Add</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
@@ -155,7 +155,7 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="deletebutton">
-                    <property name="label">Delete</property>
+                    <property name="label" translatable="yes">Delete</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>

--- a/howdy/src/cli.py
+++ b/howdy/src/cli.py
@@ -32,14 +32,14 @@ parser = argparse.ArgumentParser(
 
 # Add an argument for the command
 parser.add_argument(
-	_("command"),
+	"command",
 	help=_("The command option to execute, can be one of the following: add, clear, config, disable, list, remove, snapshot, set, test or version."),
 	metavar="command",
 	choices=["add", "clear", "config", "disable", "list", "remove", "set", "snapshot", "test", "version"])
 
 # Add an argument for the extra arguments of disable and remove
 parser.add_argument(
-	_("arguments"),
+	"arguments",
 	help=_("Optional arguments for the add, disable, remove and set commands."),
 	nargs="*")
 


### PR DESCRIPTION
  - do not translate parser arguments, because these are the keys in the `args`. And therefore, for example, `args.command` will be missing further.

  - translate button names in `main.glade`
