### PR TITLE
fix errors when install_in_site_package in meson.build.

### DIFF
--- a/howdy-gtk/meson.build
+++ b/howdy-gtk/meson.build
@@ -40,7 +40,6 @@ if get_option('install_in_site_packages')
         sources,
         py_paths,
         subdir: 'howdy-gtk',
-        install_mode: 'r--r--r--',
         install_tag: 'py_sources',
     )
 else

--- a/howdy/src/meson.build
+++ b/howdy/src/meson.build
@@ -74,7 +74,6 @@ if get_option('install_in_site_packages')
         py_sources,
         subdir: 'howdy',
         preserve_path: true,
-        install_mode: 'r--r--r--',
         install_tag: 'py_sources',
     )
 else


### PR DESCRIPTION
According to https://github.com/mesonbuild/meson/issues/12601 , py.install_sources shouldn't use install_mode.