### PR TITLE
Add text to avoid empty input for input workaround

### DIFF
--- a/howdy/src/pam/enter_device.cc
+++ b/howdy/src/pam/enter_device.cc
@@ -11,6 +11,7 @@ EnterDevice::EnterDevice()
 
   libevdev_set_name(dev_ptr, "enter device");
   libevdev_enable_event_type(dev_ptr, EV_KEY);
+  libevdev_enable_event_code(dev_ptr, EV_KEY, KEY_SPACE, nullptr);
   libevdev_enable_event_code(dev_ptr, EV_KEY, KEY_ENTER, nullptr);
 
   int err;
@@ -23,6 +24,30 @@ EnterDevice::EnterDevice()
 
   raw_uinput_device.reset(uinput_dev_ptr);
 };
+
+void EnterDevice::send_space_press() const {
+  auto *uinput_dev_ptr = raw_uinput_device.get();
+
+  int err;
+  if ((err = libevdev_uinput_write_event(uinput_dev_ptr, EV_KEY, KEY_SPACE,
+                                         1)) != 0) {
+    throw std::runtime_error(std::string("Failed to write event: ") +
+                             strerror(-err));
+  }
+
+  if ((err = libevdev_uinput_write_event(uinput_dev_ptr, EV_KEY, KEY_SPACE,
+                                         0)) != 0) {
+    throw std::runtime_error(std::string("Failed to write event: ") +
+                             strerror(-err));
+  }
+
+  if ((err = libevdev_uinput_write_event(uinput_dev_ptr, EV_SYN, SYN_REPORT,
+                                         0)) != 0)
+  {
+    throw std::runtime_error(std::string("Failed to write event: ") +
+                             strerror(-err));
+  };
+}
 
 void EnterDevice::send_enter_press() const {
   auto *uinput_dev_ptr = raw_uinput_device.get();

--- a/howdy/src/pam/enter_device.hh
+++ b/howdy/src/pam/enter_device.hh
@@ -12,6 +12,7 @@ class EnterDevice {
 
 public:
   EnterDevice();
+  void send_space_press() const;
   void send_enter_press() const;
   ~EnterDevice() = default;
 };

--- a/howdy/src/pam/main.cc
+++ b/howdy/src/pam/main.cc
@@ -409,6 +409,10 @@ auto identify(pam_handle_t *pamh, int flags, int argc, const char **argv,
           enter_device.send_enter_press();
         }
 
+        // try it one more time with an non-empty input field
+        enter_device.send_space_press();
+        enter_device.send_enter_press();
+
         if (retries == MAX_RETRIES) {
           syslog(LOG_WARNING,
                  "Failed to send enter input before the retries limit");


### PR DESCRIPTION
For the `input` workaround, we add a space key event to input some text before pressing the enter key. This avoid the error that happens due to gtk preventing empty input.

This make it so that the *workaround* works in gtk auth like:

![Screenshot from 2024-02-06 17-18-11](https://github.com/boltgolt/howdy/assets/22362177/44491498-0a92-4cfa-ae26-7c8a5c463dd1)

Pretty much after the original workaround doesn't work, we will enter a space key before pressing enter