### PR TITLE
Remove use of Environment Python

### DIFF
--- a/howdy-gtk/bin/howdy-gtk.in
+++ b/howdy-gtk/bin/howdy-gtk.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-env python3 "@script_path@" "$@"
+/usr/bin/python3 "@script_path@" "$@"

--- a/howdy-gtk/bin/howdy-gtk.in
+++ b/howdy-gtk/bin/howdy-gtk.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/bin/python3 "@script_path@" "$@"
+@python_path@ "@script_path@" "$@"

--- a/howdy-gtk/meson.build
+++ b/howdy-gtk/meson.build
@@ -65,7 +65,7 @@ interface_files = files(
 install_data(interface_files, install_dir: datadir)
 
 cli_path = join_paths(pysourcesinstalldir, 'init.py')
-conf_data = configuration_data({ 'script_path': cli_path })
+conf_data = configuration_data({ 'script_path': cli_path, 'python_path': py.full_path() })
 
 bin_name = 'howdy-gtk'
 bin = configure_file(

--- a/howdy-gtk/src/init.py
+++ b/howdy-gtk/src/init.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # Opens auth ui if requested, otherwise starts normal ui
 import sys
 

--- a/howdy-gtk/src/init.py
+++ b/howdy-gtk/src/init.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 # Opens auth ui if requested, otherwise starts normal ui
 import sys
 

--- a/howdy/src/bin/howdy.in
+++ b/howdy/src/bin/howdy.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-env python3 "@script_path@" "$@"
+/usr/bin/python3 "@script_path@" "$@"

--- a/howdy/src/bin/howdy.in
+++ b/howdy/src/bin/howdy.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/bin/python3 "@script_path@" "$@"
+@python_path@ "@script_path@" "$@"

--- a/howdy/src/cli.py
+++ b/howdy/src/cli.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 # CLI directly called by running the howdy command
 
 # Import required modules

--- a/howdy/src/cli.py
+++ b/howdy/src/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # CLI directly called by running the howdy command
 
 # Import required modules

--- a/howdy/src/compare.py
+++ b/howdy/src/compare.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 # Compare incoming video with known faces
 # Running in a local python instance to get around PATH issues
 

--- a/howdy/src/compare.py
+++ b/howdy/src/compare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # Compare incoming video with known faces
 # Running in a local python instance to get around PATH issues
 

--- a/howdy/src/meson.build
+++ b/howdy/src/meson.build
@@ -2,12 +2,13 @@ if meson.is_subproject()
 project('howdy', 'cpp', license: 'MIT', version: 'beta', meson_version: '>= 0.64.0')
 endif
 
-py = import('python').find_installation()
-py.dependency()
 
 datadir = get_option('prefix') / get_option('datadir') / 'howdy'
 py_conf = configuration_data(paths_dict)
 py_conf.set('data_dir', datadir)
+
+py = import('python').find_installation(paths_dict.get('python_path'))
+py.dependency()
 
 py_paths = configure_file(
     input: 'paths.py.in',

--- a/howdy/src/meson.build
+++ b/howdy/src/meson.build
@@ -153,7 +153,7 @@ install_man('../howdy.1')
 # endif
 
 cli_path = join_paths(pysourcesinstalldir, 'cli.py')
-conf_data = configuration_data({ 'script_path': cli_path })
+conf_data = configuration_data({ 'script_path': cli_path, 'python_path': py.full_path() })
 
 bin_name = 'howdy'
 bin = configure_file(

--- a/howdy/src/pam/main.cc
+++ b/howdy/src/pam/main.cc
@@ -47,7 +47,7 @@
 const auto DEFAULT_TIMEOUT =
     std::chrono::duration<int, std::chrono::milliseconds::period>(100);
 const auto MAX_RETRIES = 5;
-const auto PYTHON_EXECUTABLE = "/usr/bin/python3";
+const auto PYTHON_EXECUTABLE = "@python_path@";
 
 #define S(msg) gettext(msg)
 

--- a/howdy/src/pam/main.cc
+++ b/howdy/src/pam/main.cc
@@ -47,7 +47,7 @@
 const auto DEFAULT_TIMEOUT =
     std::chrono::duration<int, std::chrono::milliseconds::period>(100);
 const auto MAX_RETRIES = 5;
-const auto PYTHON_EXECUTABLE = "python3";
+const auto PYTHON_EXECUTABLE = "/usr/bin/python3";
 
 #define S(msg) gettext(msg)
 

--- a/howdy/src/pam/main.cc
+++ b/howdy/src/pam/main.cc
@@ -47,7 +47,6 @@
 const auto DEFAULT_TIMEOUT =
     std::chrono::duration<int, std::chrono::milliseconds::period>(100);
 const auto MAX_RETRIES = 5;
-const auto PYTHON_EXECUTABLE = "@python_path@";
 
 #define S(msg) gettext(msg)
 
@@ -268,12 +267,12 @@ auto identify(pam_handle_t *pamh, int flags, int argc, const char **argv,
     }
   }
 
-  const char *const args[] = {PYTHON_EXECUTABLE, // NOLINT
+  const char *const args[] = {PYTHON_EXECUTABLE_PATH, // NOLINT
                               COMPARE_PROCESS_PATH, username, nullptr};
   pid_t child_pid;
 
   // Start the python subprocess
-  if (posix_spawnp(&child_pid, PYTHON_EXECUTABLE, nullptr, nullptr,
+  if (posix_spawnp(&child_pid, PYTHON_EXECUTABLE_PATH, nullptr, nullptr,
                    const_cast<char *const *>(args), nullptr) != 0) {
     syslog(LOG_ERR, "Can't spawn the howdy process: %s (%d)", strerror(errno),
            errno);

--- a/howdy/src/pam/paths.hh.in
+++ b/howdy/src/pam/paths.hh.in
@@ -1,3 +1,4 @@
 const auto COMPARE_PROCESS_PATH = "@compare_script_path@";
 const auto CONFIG_FILE_PATH = "@config_file_path@";
 const auto USER_MODELS_DIR = "@user_models_dir@";
+const auto PYTHON_EXECUTABLE_PATH = "@python_path@";

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ dlibdatadir = get_option('dlib_data_dir') != '' ? get_option('dlib_data_dir') : 
 confdir = get_option('config_dir') != '' ? get_option('config_dir') : join_paths(get_option('prefix'), get_option('sysconfdir'), 'howdy')
 usermodelsdir = get_option('user_models_dir') != '' ? get_option('user_models_dir') : join_paths(confdir, 'models')
 logpath = get_option('log_path')
+pythonpath = get_option('python_path')
 
 config_path = join_paths(confdir, 'config.ini')
 
@@ -12,6 +13,7 @@ paths_dict = {
     'dlib_data_dir': dlibdatadir,
     'user_models_dir': usermodelsdir,
     'log_path': logpath,
+    'python_path': pythonpath
 }
 
 # We need to keep this order beause howdy-gtk defines the gtk script path which is used later in howdy

--- a/meson.options
+++ b/meson.options
@@ -6,4 +6,5 @@ option('user_models_dir', type: 'string', value: '', description: 'Set the user 
 option('log_path', type: 'string', value: '/var/log/howdy', description: 'Set the log file path')
 option('install_in_site_packages', type: 'boolean', value: false, description: 'Install howdy python files in site packages')
 option('py_sources_dir', type: 'string', value: '', description: 'Set the python sources directory')
+option('python_path', type: 'string', value: '/usr/bin/python', description: 'Set the path to the python executable')
 option('install_pam_config', type: 'boolean', value: false, description: 'Install pam config file (for Debian/Ubuntu)')


### PR DESCRIPTION
Hi,

I was running this on Arch Kernel 6.8.2 and I recently moved from the howdy AUR package to the howdy-beta-git  package.

I use Pyenv to manage multiple python versions and howdy seems to always want to use the environment python, which I believe is incorrect behavior, especially from a security standpoint wherein (this example is admittedly quite stupid, but I hope it tracks) a malicious program could launch a subprocess with sudo that uses howdy and a modified environment to launch an executable of the attackers choice from the PAM context as long as it is named python.

This patch removes the use of the "!/usr/bin/env python3" and replaces it with "!/usr/bin/python3" and also changes the python3 executable to "/usr/bin/python3" in "compare.py".

I have patched and installed this on my local system and it seems to work fine.

I hope this helps!