### PR TITLE
Fix datetime.datetime.utcnow()

### DIFF
--- a/howdy/src/cli/snap.py
+++ b/howdy/src/cli/snap.py
@@ -3,7 +3,7 @@
 # Import required modules
 import os
 import configparser
-import datetime
+from datetime import timezone, datetime
 import snapshot
 import paths_factory
 from recorders.video_capture import VideoCapture
@@ -41,7 +41,7 @@ while True:
 # Generate a snapshot image from the frames
 file = snapshot.generate(frames, [
 	_("GENERATED SNAPSHOT"),
-	_("Date: ") + datetime.datetime.utcnow().strftime("%Y/%m/%d %H:%M:%S UTC"),
+	_("Date: ") + datetime.now(timezone.utc).strftime("%Y/%m/%d %H:%M:%S UTC"),
 	_("Dark threshold config: ") + str(config.getfloat("video", "dark_threshold", fallback=60.0)),
 	_("Certainty config: ") + str(config.getfloat("video", "certainty", fallback=3.5))
 ])

--- a/howdy/src/compare.py
+++ b/howdy/src/compare.py
@@ -17,7 +17,7 @@ import json
 import configparser
 import dlib
 import cv2
-import datetime
+from datetime import timezone, datetime
 import atexit
 import subprocess
 import snapshot
@@ -71,7 +71,7 @@ def make_snapshot(type):
 	"""Generate snapshot after detection"""
 	snapshot.generate(snapframes, [
 		type + _(" LOGIN"),
-		_("Date: ") + datetime.datetime.utcnow().strftime("%Y/%m/%d %H:%M:%S UTC"),
+		_("Date: ") + datetime.now(timezone.utc).strftime("%Y/%m/%d %H:%M:%S UTC"),
 		_("Scan time: ") + str(round(time.time() - timings["fr"], 2)) + "s",
 		_("Frames: ") + str(frames) + " (" + str(round(frames / (time.time() - timings["fr"]), 2)) + "FPS)",
 		_("Hostname: ") + os.uname().nodename,

--- a/howdy/src/snapshot.py
+++ b/howdy/src/snapshot.py
@@ -3,7 +3,7 @@
 # Import modules
 import cv2
 import os
-import datetime
+from datetime import timezone, datetime
 import numpy as np
 import paths_factory
 
@@ -53,7 +53,7 @@ def generate(frames, text_lines):
 		os.makedirs(paths_factory.snapshots_dir_path())
 
 	# Generate a filename based on the current time
-	filename = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%S.jpg")
+	filename = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.jpg")
 	filepath = paths_factory.snapshot_path(filename)
 	# Write the image to that file
 	cv2.imwrite(filepath, snap)


### PR DESCRIPTION
Update datetime since datetime.utcnow() was deprecated since Python 3.12.

_Please make sure to target the "dev" branch if it exists_
_REMOVE THIS MESSAGE IN THE PULL REQUEST_
