### PR TITLE
Update README.md for Fedora 41 users

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ sudo dnf copr enable principis/howdy
 sudo dnf --refresh install howdy
 ```
 
+*Note:* Fedora 41 [removed support for Python2](https://fedoraproject.org/wiki/Changes/RetirePython2.7), but at this point in time Howdy still depends on it. If the install fails, you can fix this by installing the beta Repository and removing the release version:
+
+```
+sudo dnf copr remove principis/howdy
+sudo dnf copr enable principis/howdy-beta
+sudo dnf --refresh install howdy
+```
+
 See the link to the COPR repository for detailed configuration steps.
 
 ### openSUSE


### PR DESCRIPTION
Since pam_python depends on python2 and python2 cannot be installed through fedoras repositories the installation will fail.

The beta of Howdy has fixed this issue, but not the stable version.

The temporary fix is to install the beta repository.
This can also be found in the comment thread of the beta repository, but it requires some searching.