### PR TITLE
Fix unwanted unlocks when auth client subprocesses exit with 0

### DIFF
--- a/howdy/src/pam/main.cc
+++ b/howdy/src/pam/main.cc
@@ -290,7 +290,7 @@ auto identify(pam_handle_t *pamh, int flags, int argc, const char **argv,
   // zombie process)
   optional_task<int> child_task([&] {
     int status;
-    wait(&status);
+    waitpid(child_pid, &status, 0);
     {
       std::unique_lock<std::mutex> lock(mutx);
       if (confirmation_type == ConfirmationType::Unset) {


### PR DESCRIPTION
Closes #969

Originally did not want to create a PR, since this is not the only thing I would change about the pam module and I don't want to get involved.

But then I figured I just create it and hope it gets merged.