### PR TITLE
Replace deprecated datetime.utcnow()

### DIFF
--- a/howdy/src/compare.py
+++ b/howdy/src/compare.py
@@ -71,7 +71,7 @@ def make_snapshot(type):
 	"""Generate snapshot after detection"""
 	snapshot.generate(snapframes, [
 		type + _(" LOGIN"),
-		_("Date: ") + datetime.datetime.utcnow().strftime("%Y/%m/%d %H:%M:%S UTC"),
+		_("Date: ") + datetime.datetime.now(datetime.UTC).strftime("%Y/%m/%d %H:%M:%S UTC"),
 		_("Scan time: ") + str(round(time.time() - timings["fr"], 2)) + "s",
 		_("Frames: ") + str(frames) + " (" + str(round(frames / (time.time() - timings["fr"]), 2)) + "FPS)",
 		_("Hostname: ") + os.uname().nodename,


### PR DESCRIPTION
Whenever using howdy in the console, this annoying deprecation warning is printed
```
/lib/security/howdy/compare.py:57: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  "Date: " + datetime.datetime.utcnow().strftime("%Y/%m/%d %H:%M:%S UTC"),
```

This PR replaces the datetime.utcnow() to fix this.