### PR TITLE
feat(config): better EDITOR handling

### DIFF
--- a/howdy/src/cli/config.py
+++ b/howdy/src/cli/config.py
@@ -3,21 +3,40 @@
 # Import required modules
 import os
 import subprocess
+import shutil
 import paths_factory
 
 from i18n import _
 
-# Let the user know what we're doing
-print(_("Opening config.ini in the default editor"))
-
-# Default to the nano editor
-editor = "/bin/nano"
+# Determine the editor to use
+editor = None
+preferred_editor = os.environ.get("EDITOR")
+nano_path = shutil.which("nano")
+vi_path = shutil.which("vi")
 
 # Use the user preferred editor if available
-if "EDITOR" in os.environ:
-	editor = os.environ["EDITOR"]
-elif os.path.isfile("/etc/alternatives/editor"):
-	editor = "/etc/alternatives/editor"
+if preferred_editor:
+    if shutil.which(preferred_editor):
+        editor = preferred_editor
 
-# Open the editor as a subprocess and fork it
-subprocess.call([editor, paths_factory.config_file_path()])
+if not editor:
+    if nano_path:
+        editor = nano_path
+    elif vi_path:
+        editor = vi_path
+
+if editor:
+    editor_name = os.path.basename(editor)
+
+    # Let the user know what we're doing
+    print(_("Opening config.ini in {editor}").format(editor=editor_name))
+
+    # Open the editor as a subprocess and fork it
+    try:
+        subprocess.call([editor, paths_factory.config_file_path()])
+    except Exception as e:
+        print(_("Failed to open editor: {error}").format(error=e))
+else:
+    print(_("Error: Could not find a suitable text editor."))
+    print(_("Please install 'nano' or 'vi', or set the EDITOR environment variable."))
+    print(_("If you are running this command with sudo, try 'sudo -E howdy config' to preserve your EDITOR variable."))


### PR DESCRIPTION
The current EDITOR handling is a bit lacking.

Improvements:

- check that the editor exists before trying to spawn a subprocess
- add vi as nano alternative
- if everything else fails, perhaps the user is using sudo. Suggest using 'sudo -E howdy [...]', as otherwise the command would run in a non-interactive shell (i.e. without sourcing the initialization files), and no environment variable is carried over (including EDITOR) unless explicitly preserved

Related:
- https://github.com/boltgolt/howdy/issues/983
- https://github.com/boltgolt/howdy/issues/1000