### PR TITLE
Fix: Resolve SyntaxWarning by Adding Raw String Prefix to Regex in howdy.postinst

### DIFF
--- a/howdy/debian/postinst
+++ b/howdy/debian/postinst
@@ -128,9 +128,9 @@ handleStatus(sc(cmd))
 DLIB_DIR = None
 # A regex of all files to ignore while unpacking the archive
 excludes = re.compile(
-	"davisking-dlib-\w+/(dlib/(http_client|java|matlab|test/)|"
-	"(docs|examples|python_examples)|"
-	"tools/(archive|convert_dlib_nets_to_caffe|htmlify|imglab|python/test|visual_studio_natvis))"
+    r"davisking-dlib-\w+/(dlib/(http_client|java|matlab|test/)|"
+    r"(docs|examples|python_examples)|"
+    r"tools/(archive|convert_dlib_nets_to_caffe|htmlify|imglab|python/test|visual_studio_natvis))"
 )
 
 # Open the archive


### PR DESCRIPTION
# Fix: Add Raw String Prefix to Regex in `howdy.postinst`

## Summary
This Pull Request fixes a `SyntaxWarning` caused by an invalid escape sequence in the `howdy.postinst` file. The issue was due to a missing raw string (`r`) prefix in the regular expression, which led to potential misinterpretation of backslashes (`\`). This update ensures proper handling of escape sequences and removes the warning.

---

## Changes Made
The following changes were made to address the issue:

- **Original Code**:
  ```python
  excludes = re.compile(
      "davisking-dlib-\w+/(dlib/(http_client|java|matlab|test/)|"
      "(docs|examples|python_examples)|"
      "tools/(archive|convert_dlib_nets_to_caffe|htmlify|imglab|python/test|visual_studio_natvis))"
  )
  ```

- **Updated Code**:
  ```python
  excludes = re.compile(
      r"davisking-dlib-\w+/(dlib/(http_client|java|matlab|test/)|"
      r"(docs|examples|python_examples)|"
      r"tools/(archive|convert_dlib_nets_to_caffe|htmlify|imglab|python/test|visual_studio_natvis))"
  )
  ```

The update includes the addition of `r` prefixes to all string literals in the regular expression. This ensures that backslashes (`\`) are treated literally and interpreted correctly by Python’s `re` module.

---

## Reason for Fix
The `SyntaxWarning` was observed because Python interprets backslashes in strings as escape characters unless explicitly told otherwise using the `r` prefix. Without this prefix, Python raises a warning like this:

```
SyntaxWarning: invalid escape sequence '\w'
```

### Impact of the Issue
- **Warnings During Execution**: Running the code could lead to unnecessary warnings, indicating a potential bug.
- **Incorrect Regex Behavior**: Without proper escaping, the regular expression may not work as intended.

By adding the `r` prefix, we ensure the regex functions correctly without any warnings.

---

## Testing
The fix was tested to ensure correctness:

1. **Validation of Changes**:
   - Ran the script after applying the fix to confirm the `SyntaxWarning` is resolved.
   - Verified that the regular expression matches the intended patterns correctly.

2. **Regression Testing**:
   - Ensured that no other parts of the script or project functionality were affected by the change.

---

## Checklist
The following checklist confirms that all necessary steps have been completed:

- [x] The code changes have been implemented and reviewed.
- [x] The fix has been tested for correctness.
- [x] All existing functionality remains unaffected.
- [x] The code adheres to Python best practices.

---

## Related Issues
This Pull Request resolves the following issue:
- **SyntaxWarning** for invalid escape sequences in the `howdy.postinst` script.

---