### PR TITLE
Fix SyntaxWarning for invalid escape sequence in regex

### DIFF
--- a/howdy/src/rubberstamps/__init__.py
+++ b/howdy/src/rubberstamps/__init__.py
@@ -73,7 +73,7 @@ def execute(config, gtk_proc, opencv):
 			continue
 
 		# Parse the rule with regex
-		regex_result = re.search("^(\w+)\s+([\w\.]+)\s+([a-z]+)(.*)?$", rule, re.IGNORECASE)
+		regex_result = re.search(r"^(\w+)\s+([\w\.]+)\s+([a-z]+)(.*)?$", rule, re.IGNORECASE)
 
 		# Error out if the regex did not match (invalid line)
 		if not regex_result:


### PR DESCRIPTION
Use raw string (r'...') for regex pattern to avoid SyntaxWarning about invalid escape sequences like \w. This warning will become an error in future Python versions.

(I used Claude Code for this)