### PR TITLE
(VIBE CODED) Fix GTK authentication window not closing automatically

### DIFF
--- a/howdy-gtk/src/authsticky.py
+++ b/howdy-gtk/src/authsticky.py
@@ -127,7 +127,15 @@ class StickyWindow(gtk.Window):
 	def catch_stdin(self):
 		"""Catch input from stdin and redraw"""
 		# Wait for a line on stdin
-		comm = sys.stdin.readline()[:-1]
+		comm = sys.stdin.readline()
+
+		# If EOF (empty string), exit
+		if not comm:
+			self.exit(None, None)
+			return False
+
+		# Strip newline
+		comm = comm[:-1]
 
 		# If the line is not empty
 		if comm:

--- a/howdy/src/compare.py
+++ b/howdy/src/compare.py
@@ -31,8 +31,16 @@ def exit(code=None):
 	global gtk_proc
 
 	# Exit the auth ui process if there is one
-	if "gtk_proc" in globals():
-		gtk_proc.terminate()
+	if "gtk_proc" in globals() and gtk_proc is not None:
+		try:
+			# Try to close stdin to signal EOF to the GTK process
+			gtk_proc.stdin.close()
+			# Give it a moment to exit gracefully
+			gtk_proc.wait(timeout=0.5)
+		except:
+			# Force kill if it doesn't exit gracefully
+			gtk_proc.kill()
+			gtk_proc.wait()
 
 	# Exit compare
 	if code is not None:


### PR DESCRIPTION
I used Claude Code for this. It fixed the issue for me but I can't vouch for the code. I don't know the codebase and I don't know python too well. But the diff is small enough that hopefully you won't mind looking it over.

It did fix the issue though. At first (after installing from source and spending a LOT of time trying to get it to find dlib) the UI window would just stay open. This seems to have solved that.

AI DESCRIPTION:

The GTK window would remain open after authentication completed because it never detected when compare.py finished.

Changes:
- authsticky.py: Detect EOF on stdin and exit gracefully when the parent process closes the pipe
- compare.py: Properly close stdin and wait for GTK process to exit before force-killing it

This ensures the authentication window closes automatically instead of requiring the user to manually click to close it.
