### PR TITLE
Interrupt Ctrl+C to exit gracefully on KeyboardInterrupt

### DIFF
--- a/howdy/src/compare.py
+++ b/howdy/src/compare.py
@@ -11,7 +11,7 @@ timings = {
 
 # Interrupt Ctrl+C and exit gracefully
 import signal
-signal.signal(signal.SIGINT, lambda x, y: exit(0))
+signal.signal(signal.SIGINT, lambda x, y: exec("raise SystemExit"))
 
 # Import required modules
 import sys

--- a/howdy/src/compare.py
+++ b/howdy/src/compare.py
@@ -3,8 +3,11 @@
 
 # Intercept Ctrl+C and exit gracefully
 import signal
-signal.signal(signal.SIGINT, lambda x, y: exec("raise SystemExit"))
 
+def handle_sigint(signum, frame):
+	raise SystemExit
+
+signal.signal(signal.SIGINT, handle_sigint)
 # Import time so we can start timing asap
 import time
 

--- a/howdy/src/compare.py
+++ b/howdy/src/compare.py
@@ -2,12 +2,12 @@
 # Running in a local python instance to get around PATH issues
 
 # Intercept Ctrl+C and exit gracefully
-import signal
-
 def handle_sigint(signum, frame):
 	raise SystemExit
 
+import signal
 signal.signal(signal.SIGINT, handle_sigint)
+
 # Import time so we can start timing asap
 import time
 

--- a/howdy/src/compare.py
+++ b/howdy/src/compare.py
@@ -1,6 +1,10 @@
 # Compare incoming video with known faces
 # Running in a local python instance to get around PATH issues
 
+# Intercept Ctrl+C and exit gracefully
+import signal
+signal.signal(signal.SIGINT, lambda x, y: exec("raise SystemExit"))
+
 # Import time so we can start timing asap
 import time
 
@@ -8,10 +12,6 @@ import time
 timings = {
 	"st": time.time()
 }
-
-# Interrupt Ctrl+C and exit gracefully
-import signal
-signal.signal(signal.SIGINT, lambda x, y: exec("raise SystemExit"))
 
 # Import required modules
 import sys

--- a/howdy/src/compare.py
+++ b/howdy/src/compare.py
@@ -9,6 +9,10 @@ timings = {
 	"st": time.time()
 }
 
+# Interrupt Ctrl+C and exit gracefully
+import signal
+signal.signal(signal.SIGINT, lambda x, y: exit(0))
+
 # Import required modules
 import sys
 import os


### PR DESCRIPTION
Catches SIGINT in the event the user presses Ctrl+C to cancel a sudo request and exits gracefully, rather than outputting the traceback into the terminal.